### PR TITLE
Rôle managed users

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: betagouv
 name: common_base_roles
-version: 1.1.2
+version: 1.2.0
 readme: README.md
 authors:
   - Aurélien Merel <aurelien.merel@beta.gouv.fr>

--- a/roles/managed_users/defaults/main.yml
+++ b/roles/managed_users/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+managed_users_group: sudo
+managed_users_can_sudo: true
+managed_users_can_sudo_nopasswd: false
+managed_users_home_base_dir: /home

--- a/roles/managed_users/meta/argument_specs.yml
+++ b/roles/managed_users/meta/argument_specs.yml
@@ -1,0 +1,26 @@
+---
+argument_specs:
+  main:
+    author:
+      - Aurélien Merel
+    version_added: 1.2.0
+    options:
+      managed_users_group:
+        type: str
+        description: 'Groupe dont les comptes système sont gérés par ce rôle'
+      managed_users:
+        type: list
+        elements: dict
+        required: true
+        description:
+          - Liste des comptes devant être dans le groupe.
+          - Les comptes présents sur le système mais non configurés dans cette liste seront supprimés.
+      managed_users_home_base_dir:
+        type: str
+        description: Répertoire de base sous lequel créer les répertoires personnels
+      managed_users_can_sudo:
+        type: bool
+        description: 'Le groupe doit-il être présent dans /etc/sudoers ?'
+      managed_users_can_sudo_nopasswd:
+        type: bool
+        description: 'Si le group a accès sudo, est-ce sans mot de passe ?'

--- a/roles/managed_users/tasks/ansible_login_user_is_deleted.yml
+++ b/roles/managed_users/tasks/ansible_login_user_is_deleted.yml
@@ -1,0 +1,18 @@
+---
+- name: Pause if we are about to remove the user we are logged in as
+  pause:
+    prompt: |
+      **** WARNING ****
+      User {{ _managed_users_whoami_cmd.stdout }} is about to be deleted but Ansible is using it. Change your configuration and continue. Valid users are now: {{ managed_users | map(attribute='login') | join (', ') }}.
+      Press [ENTER] once your have updated your configuration, or Ctrl-C to abort.
+      *****************
+  check_mode: no
+
+- name: Reset SSH connection before deleting user
+  meta: reset_connection
+
+- name: Current logged in user for Ansible is known
+  command:
+    cmd: whoami
+  become: false
+  register: _managed_users_whoami_cmd2

--- a/roles/managed_users/tasks/main.yml
+++ b/roles/managed_users/tasks/main.yml
@@ -1,0 +1,82 @@
+---
+- name: Group for managed users exists
+  group:
+    name: "{{ managed_users_group }}"
+    state: present
+
+- name: Group's sudo access is as configured
+  community.general.sudoers:
+    name: ansible-managed-users-{{ managed_users_group }}
+    group: "{{ managed_users_group }}"
+    commands: ALL
+    runas: ALL
+    state: "{{ managed_users_can_sudo | ternary('present', 'absent') }}"
+    nopassword: "{{ managed_users_can_sudo_nopasswd }}"
+
+- name: Groups content is known
+  getent:
+    database: group
+    key: "{{ managed_users_group }}"
+  check_mode: no
+
+- set_fact:
+    _current_managed_users: "{{ getent_group[managed_users_group][2] | default('') | split (',') | difference(['']) }}"
+    _wanted_managed_users: "{{ managed_users | map(attribute='login') }}"
+- set_fact:
+    _unwanted_managed_users: "{{ _current_managed_users | difference(_wanted_managed_users) }}"
+
+- name: Managed users accounts exist
+  user:
+    name: "{{ item.login }}"
+    groups: "{{ [managed_users_group] + (item.additional_groups | default([])) }}"
+    append: false
+    home: "{{ item.home | default(managed_users_home_base_dir ~ '/' ~ item.login) }}"
+    shell: "{{ item.shell | default('/bin/sh') }}"
+    password: "{{ item.password_hash | default(omit) }}"
+    update_password: on_create
+    state: present
+  loop: "{{ managed_users }}"
+
+- name: SSH keys are exclusively present for managed users
+  authorized_key:
+    user: "{{ item.login }}"
+    key: "{{ item.authorized_keys | default('') }}"
+    exclusive: yes
+  loop: "{{ managed_users }}"
+
+- name: Managed users can read their home directory
+  file:
+    path: "{{ item.home | default(managed_users_home_base_dir ~ '/' ~ item.login) }}"
+    owner: "{{ item.login }}"
+    mode: "u+rX"
+    recurse: no
+  loop: "{{ managed_users }}"
+
+- name: Managed users can read their .ssh folder and its content
+  file:
+    path: "{{ item.home | default(managed_users_home_base_dir ~ '/' ~ item.login) }}/.ssh"
+    owner: "{{ item.login }}"
+    mode: "u+rX"
+    recurse: yes
+  loop: "{{ managed_users }}"
+  
+- name: Current logged in user for Ansible is known
+  command:
+    cmd: whoami
+  become: false
+  register: _managed_users_whoami_cmd
+
+- include_tasks: ansible_login_user_is_deleted.yml
+  when: _managed_users_whoami_cmd.stdout in _unwanted_managed_users
+
+- name: Fail if we are still about to remove the user we are logged in as
+  fail:
+    msg: "ERROR. User '{{ _managed_users_whoami_cmd.stdout }}' is still used by Ansible SSH connection but is due for deletion. Change your SSH or Ansible configuration and start again."
+  when: _managed_users_whoami_cmd2 is defined and _managed_users_whoami_cmd2.stdout in _unwanted_managed_users
+
+- name: Unwanted managed users do not exist on the system
+  user:
+    name: "{{ item }}"
+    state: absent
+    force: yes
+  loop: "{{ _unwanted_managed_users }}"


### PR DESCRIPTION
Rôle permettant la gestion de comptes d'administration système avec accès `sudo` et de leurs clés SSH associées.