### PR TITLE
Ajout de fonctionnalités pour managed users 

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: betagouv
 name: common_base_roles
-version: 1.6.0
+version: 1.7.0
 readme: README.md
 authors:
   - Aurélien Merel <aurelien.merel@beta.gouv.fr>

--- a/roles/managed_users/defaults/main.yml
+++ b/roles/managed_users/defaults/main.yml
@@ -3,3 +3,6 @@ managed_users_group: sudo
 managed_users_can_sudo: true
 managed_users_can_sudo_nopasswd: false
 managed_users_home_base_dir: /home
+managed_users_default_shell: /bin/sh
+managed_users_require_password_change: true
+managed_users_remove_unwanted: true

--- a/roles/managed_users/meta/argument_specs.yml
+++ b/roles/managed_users/meta/argument_specs.yml
@@ -14,13 +14,28 @@ argument_specs:
         required: true
         description:
           - Liste des comptes devant être dans le groupe.
-          - Les comptes présents sur le système mais non configurés dans cette liste seront supprimés.
+          - Les comptes présents sur le système mais non configurés dans cette liste seront supprimés si C(managed_users_remove_unwanted) est à C(true). Chaque dictionnaire contient les éléments suivants.
+          - 'C(login) (requis) : identifiant sur le système'
+          - 'C(authorized_keys) (requis) : clé(s) publique(s) SSH'
+          - 'C(exclusive_keys) : les clés SSH spécifiées sont-elles exclusives'
+          - 'C(shell) : interpréteur de commande (si non spécifié, C(managed_users_default_shell) est utilisé)'
+          - 'C(home) : répertoire personnel (sinon spécifié un sous-répertoire nommé après C(login) est créé sous C(managed_users_home_base_dir))'
+          - 'C(password) : mot de passe initial'
       managed_users_home_base_dir:
         type: str
         description: Répertoire de base sous lequel créer les répertoires personnels
       managed_users_can_sudo:
         type: bool
-        description: 'Le groupe doit-il être présent dans /etc/sudoers ?'
+        description: 'Le groupe doit-il être présent dans C(/etc/sudoers) ?'
       managed_users_can_sudo_nopasswd:
         type: bool
-        description: 'Si le group a accès sudo, est-ce sans mot de passe ?'
+        description: 'Si le groupe a accès sudo, est-ce sans mot de passe ?'
+      managed_users_remove_unwanted:
+        type: bool
+        description: "Si le groupe présent sur le système contient des comptes non listés dans Ansible, faut-il les supprimer du système ?"
+      managed_users_default_shell:
+        type: str
+        description: "Interpréteur de commandes par défaut pour les comptes où ce n'est pas spécifié explicitement dans C(managed_users)"
+      managed_users_require_password_change:
+        type: bool
+        description: "Pour les comptes qui ont un mot de passe spécifié, faut-il requérir que ce mots de passent soient changés à la prochaine connxion ?"

--- a/roles/managed_users/tasks/main.yml
+++ b/roles/managed_users/tasks/main.yml
@@ -23,7 +23,7 @@
     _current_managed_users: "{{ getent_group[managed_users_group][2] | default('') | split (',') | difference(['']) }}"
     _wanted_managed_users: "{{ managed_users | map(attribute='login') }}"
 - set_fact:
-    _unwanted_managed_users: "{{ _current_managed_users | difference(_wanted_managed_users) }}"
+    _unwanted_managed_users: "{{ managed_users_remove_unwanted | ternary(_current_managed_users | difference(_wanted_managed_users), []) }}"
 
 - name: Managed users accounts exist
   user:
@@ -31,17 +31,33 @@
     groups: "{{ [managed_users_group] + (item.additional_groups | default([])) }}"
     append: false
     home: "{{ item.home | default(managed_users_home_base_dir ~ '/' ~ item.login) }}"
-    shell: "{{ item.shell | default('/bin/sh') }}"
-    password: "{{ item.password_hash | default(omit) }}"
-    update_password: on_create
-    state: present
+    shell: "{{ item.shell | default(managed_users_default_shell) }}"
   loop: "{{ managed_users }}"
+
+- name: Shadow content is known
+  getent:
+    database: shadow
+  check_mode: no
+  no_log: true
+
+- name: Account passwords are set if defined in Ansible and not already set on system
+  user:
+    name: "{{ item.login }}"
+    password: "{{ item.password | password_hash('sha512') }}"
+  loop: "{{ managed_users }}"
+  when: "'password' in item and getent_shadow[item.login][0] == '!'"
+
+- name: Users with newly set password are required to change it at next login
+  command:
+    cmd: chage -d 0 "{{ item.login }}"
+  loop: "{{ managed_users }}"
+  when: "'password' in item and getent_shadow[item.login][0] == '!' and managed_users_require_password_change"
 
 - name: SSH keys are exclusively present for managed users
   authorized_key:
     user: "{{ item.login }}"
     key: "{{ item.authorized_keys | default('') }}"
-    exclusive: yes
+    exclusive: "{{ item.exclusive_keys | default(True) }}"
   loop: "{{ managed_users }}"
 
 - name: Managed users can read their home directory


### PR DESCRIPTION
Fonctionnalités en plus pour le rôle `managed_users` :
- possibilté de spécifier un interpréteur de commande par défaut pour tous les comptes
- possibilité de choisir que les clés publiques SSH soient exclusives ou pas
- possibilité de choisir si oui ou non les comptes système en trop seront supprimés
- initialisation du mot de passe d'une personne (si configuré) même si le compte existe déjà, sauf si un mot de passe est déjà défini sur le système ; possibilité de rendre obligatoire le changement de mot de passe de la personne à la première connexion