### PR TITLE
Extension wireguard

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: betagouv
 name: common_base_roles
-version: 1.9.0
+version: 1.10.0
 readme: README.md
 authors:
   - Aurélien Merel <aurelien.merel@beta.gouv.fr>

--- a/roles/wireguard/meta/argument_specs.yml
+++ b/roles/wireguard/meta/argument_specs.yml
@@ -27,6 +27,7 @@ argument_specs:
           - "C(name) : nom humain du client."
           - "C(public_key) : clé publique Wireguard."
           - "C(ip) : adresse IP attribuée à ce client, sans masque de sous-réseau, et devant être dans le réseau défini par C(wireguard_if_ip)."
+          - "C(remote) : optionnellement une C(adresse:port) pour joindre pair distant"
       wireguard_private_key:
         type: str
         description: "Clé privée de Wireguard. Si non spécifiée, une clé est générée au premier lancement. La clé publique sera affichée par la recette."

--- a/roles/wireguard/templates/wg-if.conf.j2
+++ b/roles/wireguard/templates/wg-if.conf.j2
@@ -7,4 +7,7 @@ ListenPort = {{ wireguard_listen_port }}
 [Peer] # {{ wgpeer.name }}
 PublicKey = {{ wgpeer.public_key }}
 AllowedIPs = {{ wgpeer.ip }}/32
+{% if 'remote' in wgpeer %}
+Endpoint = {{ wgpeer.remote }}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
Support du paramètre `Endpoint` pour les pairs Wireguard.