### PR TITLE
Correction tâche dans managed_users

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: betagouv
 name: common_base_roles
-version: 1.10.1
+version: 1.10.2
 readme: README.md
 authors:
   - Aurélien Merel <aurelien.merel@beta.gouv.fr>

--- a/roles/managed_users/tasks/ansible_login_user_is_deleted.yml
+++ b/roles/managed_users/tasks/ansible_login_user_is_deleted.yml
@@ -15,4 +15,5 @@
   command:
     cmd: whoami
   become: false
+  changed_when: false
   register: _managed_users_whoami_cmd2


### PR DESCRIPTION
La tâche d'exécution `whoami` rapportait un changement alors qu'elle ne change pas l'état du système.